### PR TITLE
updated camunda to 7.24 and spring boot to 3.5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>3.4.4</version>
+        <version>3.5.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -27,7 +27,7 @@
       <dependency>
         <groupId>org.camunda.bpm</groupId>
         <artifactId>camunda-bom</artifactId>
-        <version>7.23.0</version>
+        <version>7.24.0</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
Docker Image ist bereits erstellt und veröffentlicht: [0.0.9](https://hub.docker.com/layers/enviteconsulting/carbon-reductor-c7-example-workflow/0.0.9/images/sha256-c341213a4c840810ae9f95b425392ffcc6699e2f2b2f6baf3ab3a7e79864ae4f) und [latest](https://hub.docker.com/layers/enviteconsulting/carbon-reductor-c7-example-workflow/latest/images/sha256-c341213a4c840810ae9f95b425392ffcc6699e2f2b2f6baf3ab3a7e79864ae4f)